### PR TITLE
chore(release): bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.2.1] - 2026-06-28
+- deps: Actualización Spring Boot 4.0.6 → 4.1.0
+- deps: Actualización Spring Cloud 2025.1.0 → 2025.1.2
+- deps: Actualización OpenPDF 3.0.3 → 3.0.5
+- deps: Actualización SpringDoc OpenAPI 3.0.2 → 3.0.3
+
 ## [2.2.0] - 2026-06-06
 - feat: Nuevo serializador JSON utilitario (Jsonifier) con patrón Builder
 - feat: Nuevos campos precioTotalSinIva/precioTotalConIva en ArticuloMovimiento

--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@
 [![ETEREA.report-service Build JVM Image](https://github.com/ETEREA-services/ETEREA.report-service/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/ETEREA.report-service/actions/workflows/maven.yml)
 [![Documentation](https://github.com/ETEREA-services/ETEREA.report-service/actions/workflows/generate-docs.yml/badge.svg)](https://github.com/ETEREA-services/ETEREA.report-service/actions/workflows/generate-docs.yml)
 [![Java](https://img.shields.io/badge/Java-25-red.svg)](https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html)
-[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.6-brightgreen.svg)](https://spring.io/projects/spring-boot)
-[![Version](https://img.shields.io/badge/Version-2.2.0-blue.svg)](https://github.com/ETEREA-services/ETEREA.report-service)
+[![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg)](https://spring.io/projects/spring-boot)
+[![Version](https://img.shields.io/badge/Version-2.2.1-blue.svg)](https://github.com/ETEREA-services/ETEREA.report-service)
 
 Servicio de reportes para la plataforma Eterea: generación de reportes, notificaciones por email y gestión de documentos.
 
-## Cambios recientes destacados (v2.2.0)
+## Cambios recientes destacados (v2.2.1)
+
+- **Actualización de dependencias:** Spring Boot 4.0.6 → 4.1.0, Spring Cloud 2025.1.0 → 2025.1.2, OpenPDF 3.0.3 → 3.0.5, SpringDoc OpenAPI 3.0.2 → 3.0.3
+
+### v2.2.0
 
 - **Serializador JSON utilitario:** Nuevo Jsonifier con patrón Builder para depuración de modelos
 - **Campos extendidos en facturación:** precioTotalSinIva/precioTotalConIva en ArticuloMovimiento y métodos jsonify() en ClienteMovimiento e InvoiceData

--- a/docs/diagrams/mermaid/report-engine-class-diagram.mmd
+++ b/docs/diagrams/mermaid/report-engine-class-diagram.mmd
@@ -66,14 +66,6 @@ classDiagram
         -createResponseEntity(String filename) ResponseEntity~Resource~
     }
 
-    class ReportConstants {
-        <<Utility Class>>
-        +String DEFAULT_FONT
-        +float DEFAULT_MARGIN
-        +float HEADER_HEIGHT
-        +float FOOTER_HEIGHT
-    }
-
     PdfReportBuilder --> PageSection : uses
     PdfReportBuilder --> ReportSection : composes
     PdfReportBuilder --> HeaderFooterPageEvent : configures
@@ -82,7 +74,6 @@ classDiagram
     SampleReportService --> PageSection : creates
     SampleReportService --> ReportSection : creates
     SampleReportController --> SampleReportService : calls
-    SampleReportService --> ReportConstants : references
 
     note for PdfReportBuilder "Builder pattern para\nconstrucción flexible de PDFs\ncon OpenPDF"
     note for PageSection "Functional interface\npara renderizar headers/footers\ndinámicos en cada página"

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.termascacheuta.eterea</groupId>
 	<artifactId>report-service</artifactId>
-	<version>2.2.0</version>
+	<version>2.2.1</version>
 	<name>ETEREA.report-service</name>
 	<description>eterea.report-service</description>
 	<url/>
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>25</java.version>
-		<spring-cloud.version>2025.1.0</spring-cloud.version>
+		<spring-cloud.version>2025.1.2</spring-cloud.version>
 		<sonar.organization>eterea-services</sonar.organization>
 		<sonar.projectKey>ETEREA-services_ETEREA.report-service</sonar.projectKey>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -68,7 +68,7 @@
 		        <dependency>
             <groupId>com.github.librepdf</groupId>
             <artifactId>openpdf</artifactId>
-            <version>3.0.3</version>
+            <version>3.0.5</version>
         </dependency>
 		<!-- ZXING BarCode and QRCode-->
 		<dependency>
@@ -98,7 +98,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.2</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Closes #59

## Descripción

Actualización de dependencias y documentación para la versión **v2.2.1** del servicio de reportes ETEREA.

## Cambios Realizados

- **deps:** Spring Boot 4.0.6 → 4.1.0
- **deps:** Spring Cloud 2025.1.0 → 2025.1.2
- **deps:** OpenPDF 3.0.3 → 3.0.5
- **deps:** SpringDoc OpenAPI 3.0.2 → 3.0.3
- **docs:** CHANGELOG.md actualizado con registro de v2.2.1
- **docs:** README.md actualizado (badges y sección de cambios recientes)
- **docs:** Diagrama de clases Mermaid limpia clases obsoletas (ReportConstants)
- **version:** pom.xml bumped 2.2.0 → 2.2.1

## Verificación

- [ ] Compilación exitosa: `mvn clean compile`
- [ ] Pruebas unitarias: `mvn test`
- [ ] Construcción de imagen Docker: `docker build .`
- [ ] Pipelines de CI/CD en GitHub Actions
